### PR TITLE
enable CORS in app config to access local service from local webclient

### DIFF
--- a/kommonitor-importer-app/src/main/java/org/n52/kommonitor/importer/KommonitorDataManagementApiClientConfiguration.java
+++ b/kommonitor-importer-app/src/main/java/org/n52/kommonitor/importer/KommonitorDataManagementApiClientConfiguration.java
@@ -5,7 +5,12 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 /**
  * @author <a href="mailto:s.drost@52north.org">Sebastian Drost</a>
@@ -31,5 +36,19 @@ public class KommonitorDataManagementApiClientConfiguration implements Initializ
     @Override
     public void afterPropertiesSet() throws Exception {
         client.setBasePath(getDataManagementApiUrl());
+    }
+
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+      final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+      CorsConfiguration config = new CorsConfiguration();
+      config.setAllowCredentials(true);
+      config.addAllowedOrigin("*"); // @Value: http://localhost:8080
+      config.addAllowedHeader("*");
+      config.addAllowedMethod("*");
+      source.registerCorsConfiguration("/**/*", config);
+      FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+      bean.setOrder(0);
+      return bean;
     }
 }


### PR DESCRIPTION
while testing the connection between my local browser and a local instance of importer, CORS issues prevented the requests. 

Hence I suggest a CORS enabling, e.g. as provided in this pull request.